### PR TITLE
Added props to DateTimeField and added a behaviour on Enter keydown

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ DateTimeField
 | **mode** | string | undefined | Allows to selectively display only the time picker ('time'), date picker ('date'), or month picker ('month') |
 | **defaultText** | string | {dateTime} | Sets the initial value. Could be an empty string, or helper text. |
 | **name** | string | undefined | Sets the name of the input element. |
+| **tabIndex** | string | undefined | Sets the tabIndex of the input element. |
 
 
 **Note**: Hitting the **Enter** key from the input field will produce the same effect as an **onBlur** event.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ DateTimeField
 | **inputDisplayFormat** | string |  When there is **_no inputFormat given_**:<br> *see default format table below*. <br><br> When an **_inputFormat_** is given and it is a **string**: it takes the inputFormat. <br><br> When the **_inputFormat_** is an **array**: it takes the first inputFormat.  | Defines the *display* format of the date in the HTML input. It must be a format understandable by moment.js. <br><br> If there is an **_inputFormat_** given, the inputDisplayFormat must be one of the formats listed in the inputFormat|
 | **onChange** | function | x => console.log(x) | Callback trigger when the date changes. `x` is the new datetime value. |
 | **onBlur** | function | () => {} | Callback trigger when the date field blurs. |
+| **onEnterKeyDown** | function | () => {} | Callback trigger when the Enter key is pressed. |
 | **showToday** | boolean | true | Highlights today's date |
 | **size** | string | "md" | Changes the size of the date picker input field. Sizes: "sm", "md", "lg" |
 | **daysOfWeekDisabled** | array of integer | [] | Disables clicking on some days. Goes from 0 (Sunday) to 6 (Saturday). |
@@ -52,8 +53,6 @@ DateTimeField
 | **name** | string | undefined | Sets the name of the input element. |
 | **tabIndex** | string | undefined | Sets the tabIndex of the input element. |
 
-
-**Note**: Hitting the **Enter** key from the input field will produce the same effect as an **onBlur** event.
 
 Default Format Based on Mode
 ========

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ DateTimeField
 | **defaultText** | string | {dateTime} | Sets the initial value. Could be an empty string, or helper text. |
 | **name** | string | undefined | Sets the name of the input element. |
 
+
+**Note**: Hitting the **Enter** key from the input field will produce the same effect as an **onBlur** event.
+
 Default Format Based on Mode
 ========
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ DateTimeField
 | **inputFormat** | string or array | *see default format table below* | Defines the *accepted* date formats in the HTML input. It must be a format understandable by moment.js |
 | **inputDisplayFormat** | string |  When there is **_no inputFormat given_**:<br> *see default format table below*. <br><br> When an **_inputFormat_** is given and it is a **string**: it takes the inputFormat. <br><br> When the **_inputFormat_** is an **array**: it takes the first inputFormat.  | Defines the *display* format of the date in the HTML input. It must be a format understandable by moment.js. <br><br> If there is an **_inputFormat_** given, the inputDisplayFormat must be one of the formats listed in the inputFormat|
 | **onChange** | function | x => console.log(x) | Callback trigger when the date changes. `x` is the new datetime value. |
-| **onBlur** | function | x => console.log(x) | Callback trigger when the date field blurs. `x` is the new datetime value. |
+| **onBlur** | function | () => {} | Callback trigger when the date field blurs. |
 | **showToday** | boolean | true | Highlights today's date |
 | **size** | string | "md" | Changes the size of the date picker input field. Sizes: "sm", "md", "lg" |
 | **daysOfWeekDisabled** | array of integer | [] | Disables clicking on some days. Goes from 0 (Sunday) to 6 (Saturday). |
@@ -49,6 +49,7 @@ DateTimeField
 | **maxDate** | moment | undefined | The latest date allowed for entry in the calendar view. |
 | **mode** | string | undefined | Allows to selectively display only the time picker ('time'), date picker ('date'), or month picker ('month') |
 | **defaultText** | string | {dateTime} | Sets the initial value. Could be an empty string, or helper text. |
+| **name** | string | undefined | Sets the name of the input element. |
 
 Default Format Based on Mode
 ========

--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -154,6 +154,12 @@ export default class DateTimeField extends Component {
     this.formatValueForEvent('onBlur', event);
   };
 
+  onKeyDown = event => {
+    if (event.key === 'Enter') {
+      this.onBlur(event);
+    }
+  };
+
   checkIsValid = (value) => {
     return moment(value, this.state.inputFormat, true).isValid() || value === this.props.defaultText || value === '';
   }
@@ -496,7 +502,7 @@ export default class DateTimeField extends Component {
              ref="datetimepicker">
           <input className="form-control" onChange={this.onChange} onBlur={this.onBlur} type="text"
                  value={this.state.inputValue} {...this.props.inputProps} ref={this.props.inputRef}
-                 name={this.props.name} placeholder={this.props.defaultText}/>
+                 onKeyDown={this.onKeyDown} name={this.props.name} placeholder={this.props.defaultText}/>
               <span className="input-group-addon" onBlur={this.onBlur} onClick={this.onClick} ref="dtpbutton">
                 <span className={classnames("glyphicon", this.state.buttonIcon)}/>
               </span>

--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -17,7 +17,8 @@ export default class DateTimeField extends Component {
     mode: Constants.MODE_DATETIME,
     onChange: (x) => {
       console.log(x);
-    }
+    },
+    onBlur: () => {}
   };
 
   constructor(props) {
@@ -80,6 +81,7 @@ export default class DateTimeField extends Component {
       PropTypes.number
     ]),
     onChange: PropTypes.func,
+    onBlur: PropTypes.func,
     format: PropTypes.string,
     inputProps: PropTypes.object,
     inputFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
@@ -93,7 +95,8 @@ export default class DateTimeField extends Component {
     viewMode: PropTypes.string,
     size: PropTypes.oneOf([Constants.SIZE_SMALL, Constants.SIZE_MEDIUM, Constants.SIZE_LARGE]),
     daysOfWeekDisabled: PropTypes.arrayOf(PropTypes.number),
-    isValid: PropTypes.bool
+    isValid: PropTypes.bool,
+    name: PropTypes.string
   }
 
   componentWillReceiveProps = (nextProps) => {
@@ -130,9 +133,7 @@ export default class DateTimeField extends Component {
     return this.setState({
       inputValue: value
     }, function () {
-      if (this.props[eventName]) {
-        return this.props[eventName](moment(this.state.inputValue, this.state.inputFormat, true).format(this.props.format), value);
-      }
+      return this.props[eventName](moment(this.state.inputValue, this.state.inputFormat, true).format(this.props.format), value);
     });
 
   }
@@ -495,7 +496,7 @@ export default class DateTimeField extends Component {
              ref="datetimepicker">
           <input className="form-control" onChange={this.onChange} onBlur={this.onBlur} type="text"
                  value={this.state.inputValue} {...this.props.inputProps} ref={this.props.inputRef}
-                 placeholder={this.props.defaultText}/>
+                 name={this.props.name} placeholder={this.props.defaultText}/>
               <span className="input-group-addon" onBlur={this.onBlur} onClick={this.onClick} ref="dtpbutton">
                 <span className={classnames("glyphicon", this.state.buttonIcon)}/>
               </span>

--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -18,7 +18,8 @@ export default class DateTimeField extends Component {
     onChange: (x) => {
       console.log(x);
     },
-    onBlur: () => {}
+    onBlur: () => {},
+    onEnterKeyDown: () => {}
   };
 
   constructor(props) {
@@ -82,6 +83,7 @@ export default class DateTimeField extends Component {
     ]),
     onChange: PropTypes.func,
     onBlur: PropTypes.func,
+    onEnterKeyDown: PropTypes.func,
     format: PropTypes.string,
     inputProps: PropTypes.object,
     inputFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
@@ -157,7 +159,7 @@ export default class DateTimeField extends Component {
 
   onKeyDown = event => {
     if (event.key === 'Enter') {
-      this.onBlur(event);
+      this.props.onEnterKeyDown(event);
     }
   };
 

--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -121,16 +121,16 @@ export default class DateTimeField extends Component {
     this.setIsValid(this.checkIsValid(value));
 
     let yearDigits = this.yearDigits(value);
+    let yearIsDone = yearDigits === 4 || (yearDigits === 2 && (eventName === 'onEnterKeyDown' || eventName === 'onBlur'));
+    let dateMatchesFormat = moment(value, this.state.inputFormat, true).isValid();
 
-    if (yearDigits === 4 || (eventName === 'onBlur' && yearDigits === 2)) {
-      if (moment(value, this.state.inputFormat, true).isValid()) {
-        this.setState({
-          selectedDate: moment(value, this.state.inputFormat, true),
-          viewDate: moment(value, this.state.inputFormat, true).startOf("month")
-        });
+    if (yearIsDone && dateMatchesFormat) {
+      this.setState({
+        selectedDate: moment(value, this.state.inputFormat, true),
+        viewDate: moment(value, this.state.inputFormat, true).startOf("month")
+      });
 
-        value = moment(value, this.state.inputFormat, true).format(this.state.inputDisplayFormat);
-      }
+      value = moment(value, this.state.inputFormat, true).format(this.state.inputDisplayFormat);
     }
 
     return this.setState({
@@ -159,7 +159,7 @@ export default class DateTimeField extends Component {
 
   onKeyDown = event => {
     if (event.key === 'Enter') {
-      this.props.onEnterKeyDown(event);
+      this.formatValueForEvent('onEnterKeyDown', event);
     }
   };
 

--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -96,7 +96,8 @@ export default class DateTimeField extends Component {
     size: PropTypes.oneOf([Constants.SIZE_SMALL, Constants.SIZE_MEDIUM, Constants.SIZE_LARGE]),
     daysOfWeekDisabled: PropTypes.arrayOf(PropTypes.number),
     isValid: PropTypes.bool,
-    name: PropTypes.string
+    name: PropTypes.string,
+    tabIndex: PropTypes.string
   }
 
   componentWillReceiveProps = (nextProps) => {
@@ -500,12 +501,22 @@ export default class DateTimeField extends Component {
         />
         <div className={classnames("input-group date " + this.size(), {"has-error": !this.state.isValid})}
              ref="datetimepicker">
-          <input className="form-control" onChange={this.onChange} onBlur={this.onBlur} type="text"
-                 value={this.state.inputValue} {...this.props.inputProps} ref={this.props.inputRef}
-                 onKeyDown={this.onKeyDown} name={this.props.name} placeholder={this.props.defaultText}/>
-              <span className="input-group-addon" onBlur={this.onBlur} onClick={this.onClick} ref="dtpbutton">
-                <span className={classnames("glyphicon", this.state.buttonIcon)}/>
-              </span>
+          <input
+            className="form-control"
+            onChange={this.onChange}
+            onBlur={this.onBlur}
+            type="text"
+            tabIndex={this.props.tabIndex}
+            value={this.state.inputValue}
+            ref={this.props.inputRef}
+            onKeyDown={this.onKeyDown}
+            name={this.props.name}
+            placeholder={this.props.defaultText}
+            {...this.props.inputProps}
+          />
+          <span className="input-group-addon" onBlur={this.onBlur} onClick={this.onClick} ref="dtpbutton">
+            <span className={classnames("glyphicon", this.state.buttonIcon)}/>
+          </span>
         </div>
       </div>
     );

--- a/src/__tests__/DateTimeField-test.js
+++ b/src/__tests__/DateTimeField-test.js
@@ -215,30 +215,29 @@ describe("DateTimeField", function () {
   });
 
   describe('onKeyDown', () => {
-    let component, onBlurMock;
+    let component, onEnterKeyDownMock;
 
     beforeEach(() => {
-      component = TestUtils.renderIntoDocument(<DateTimeField dateTime={happyDate.format("x")}
-                                                                    inputFormat='DD/MM/YYYY'/>);
-      onBlurMock = jest.genMockFunction();
-      component.onBlur = onBlurMock;
+      onEnterKeyDownMock = jest.genMockFunction();
+      component = TestUtils.renderIntoDocument(
+        <DateTimeField dateTime={happyDate.format("x")} inputFormat='DD/MM/YYYY' onEnterKeyDown={onEnterKeyDownMock}/>);
     });
 
-    it('calls onBlur when the Enter key is pressed', () => {
+    it('calls onEnterKeyDown props when the Enter key is pressed', () => {
       const event = {key: 'Enter'};
 
       component.onKeyDown(event);
 
-      expect(onBlurMock.mock.calls.length).toBe(1);
-      expect(onBlurMock.mock.calls[0][0]).toEqual(event);
+      expect(onEnterKeyDownMock.mock.calls.length).toBe(1);
+      expect(onEnterKeyDownMock.mock.calls[0][0]).toEqual(event);
     });
 
-    it('does not call onBlur if any key other than Enter has been pressed', () => {
+    it('does not call onEnterKeyDown props if any key other than Enter has been pressed', () => {
       const event = {key: 'a'};
 
       component.onKeyDown(event);
 
-      expect(onBlurMock.mock.calls.length).toBe(0);
+      expect(onEnterKeyDownMock.mock.calls.length).toBe(0);
     });
   });
 });

--- a/src/__tests__/DateTimeField-test.js
+++ b/src/__tests__/DateTimeField-test.js
@@ -213,4 +213,32 @@ describe("DateTimeField", function () {
       });
     });
   });
+
+  describe('onKeyDown', () => {
+    let component, onBlurMock;
+
+    beforeEach(() => {
+      component = TestUtils.renderIntoDocument(<DateTimeField dateTime={happyDate.format("x")}
+                                                                    inputFormat='DD/MM/YYYY'/>);
+      onBlurMock = jest.genMockFunction();
+      component.onBlur = onBlurMock;
+    });
+
+    it('calls onBlur when the Enter key is pressed', () => {
+      const event = {key: 'Enter'};
+
+      component.onKeyDown(event);
+
+      expect(onBlurMock.mock.calls.length).toBe(1);
+      expect(onBlurMock.mock.calls[0][0]).toEqual(event);
+    });
+
+    it('does not call onBlur if any key other than Enter has been pressed', () => {
+      const event = {key: 'a'};
+
+      component.onKeyDown(event);
+
+      expect(onBlurMock.mock.calls.length).toBe(0);
+    });
+  });
 });

--- a/src/__tests__/DateTimeField-test.js
+++ b/src/__tests__/DateTimeField-test.js
@@ -212,32 +212,76 @@ describe("DateTimeField", function () {
         expect(setStateMock.mock.calls[0][0].inputValue).toEqual('12/12/201');
       });
     });
+
+    describe('on Enter key press', () => {
+      it('calls setState twice when year is 2 digits and is valid', () => {
+        component.yearDigits = yearDigitsMock.mockImplementation(() => 2);
+        const date = '12/12/16';
+        const selectedValue = moment(date, inputFormat, true).format();
+        const viewDate = moment(date, inputFormat, true).startOf('month').format();
+
+        component.formatValueForEvent('onEnterKeyDown', {target: {value: date}});
+
+        expect(setStateMock.mock.calls.length).toBe(2);
+        expect(setStateMock.mock.calls[0][0].selectedDate.format()).toEqual(selectedValue);
+        expect(setStateMock.mock.calls[0][0].viewDate.format()).toEqual(viewDate);
+        expect(setStateMock.mock.calls[1][0].inputValue).toEqual('12/12/2016');
+      });
+
+      it('calls setState twice when year is 4 digits and is valid', () => {
+        component.yearDigits = yearDigitsMock.mockImplementation(() => 4);
+        const date = '12/12/2016';
+        const selectedValue = moment(date, inputFormat, true).format();
+        const viewDate = moment(date, inputFormat, true).startOf('month').format();
+        component.formatValueForEvent('onEnterKeyDown', {target: {value: date}});
+
+        expect(setStateMock.mock.calls.length).toBe(2);
+        expect(setStateMock.mock.calls[0][0].selectedDate.format()).toEqual(selectedValue);
+        expect(setStateMock.mock.calls[0][0].viewDate.format()).toEqual(viewDate);
+        expect(setStateMock.mock.calls[1][0].inputValue).toEqual('12/12/2016');
+      });
+
+      it('calls setState once when year is 3 digits', () => {
+        component.yearDigits = yearDigitsMock.mockImplementation(() => 3);
+        const event = {target: {value: '12/12/201'}};
+
+        component.formatValueForEvent('onEnterKeyDown', event);
+
+        expect(setStateMock.mock.calls.length).toBe(1);
+        expect(setStateMock.mock.calls[0][0].inputValue).toEqual('12/12/201');
+      });
+    });
   });
 
+
+
   describe('onKeyDown', () => {
-    let component, onEnterKeyDownMock;
+    let component, formatValueForEventMock;
 
     beforeEach(() => {
-      onEnterKeyDownMock = jest.genMockFunction();
+      formatValueForEventMock = jest.genMockFunction();
       component = TestUtils.renderIntoDocument(
-        <DateTimeField dateTime={happyDate.format("x")} inputFormat='DD/MM/YYYY' onEnterKeyDown={onEnterKeyDownMock}/>);
+        <DateTimeField dateTime={happyDate.format('x')} inputFormat='DD/MM/YYYY' onEnterKeyDown={formatValueForEventMock}/>
+      );
+      component.formatValueForEvent = formatValueForEventMock;
     });
 
-    it('calls onEnterKeyDown props when the Enter key is pressed', () => {
+    it('calls formatValueForEvent when the Enter key is pressed', () => {
       const event = {key: 'Enter'};
 
       component.onKeyDown(event);
 
-      expect(onEnterKeyDownMock.mock.calls.length).toBe(1);
-      expect(onEnterKeyDownMock.mock.calls[0][0]).toEqual(event);
+      expect(formatValueForEventMock.mock.calls.length).toBe(1);
+      expect(formatValueForEventMock.mock.calls[0][0]).toEqual('onEnterKeyDown');
+      expect(formatValueForEventMock.mock.calls[0][1]).toEqual(event);
     });
 
-    it('does not call onEnterKeyDown props if any key other than Enter has been pressed', () => {
+    it('does not call formatValueForEvent when any key other than Enter has been pressed', () => {
       const event = {key: 'a'};
 
       component.onKeyDown(event);
 
-      expect(onEnterKeyDownMock.mock.calls.length).toBe(0);
+      expect(formatValueForEventMock.mock.calls.length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
DateTimeField now accepts 'onBlur', 'name', and 'tabIndex' props. 

Hitting 'Enter' on the input field now produces the same effect as an onBlur event.