### PR TITLE
Remove the CSS class "old" from the year picker

### DIFF
--- a/src/DateTimePickerYears.js
+++ b/src/DateTimePickerYears.js
@@ -22,7 +22,6 @@ export default class DateTimePickerYears extends Component {
     for (let i = -1; i < 11; i++) {
       classes = {
         year: true,
-        old: i === -1 | i === 10,
         active: this.props.selectedDate.year() === year,
         disabled: (minDate && year < minDate.year()) || (maxDate && year > maxDate.year())
       };


### PR DESCRIPTION
Graying out the first and last years in the years calendar by default doesn't make sense. They can be selected.
Graying only makes sense for the days calendar when displaying days from the previous and next month alongside the current month.
Only disabled months or years should be grayed out otherwise.