### PR TITLE
Do not limit the type of separator for date value

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ DateTimeField
 | **tabIndex** | string | undefined | Sets the tabIndex of the input element. |
 
 
-**NOTE:** From version 0.2.0 onwards, the datepicker now assumes that a '/' or a space will be used to separate the date values (e.g. 'Dec 2016' or '12/12/2016'). See commit [a3e86d3083] (https://github.com/MYOB-Technology/react-bootstrap-datetimepicker/commit/a3e86d308371d069c503ce8b62984b40c0a39808).
-
 Default Format Based on Mode
 ========
 

--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -142,10 +142,14 @@ export default class DateTimeField extends Component {
   }
 
   yearDigits(value) {
+    let separator = value.match(/\W/);
+    if (separator) {
+      separator = separator[0];
+    }
     if (this.props.mode === 'date') {
-      return value.split('/')[2] ? value.split('/')[2].length : 0; //assumes that format is separated by /
+      return value.split(separator)[2] ? value.split(separator)[2].length : 0;
     } else if (this.props.mode === 'month') {
-      return value.split(' ')[1] ? value.split(' ')[1].length : 0; //assumes that format is separated by a space
+      return value.split(separator)[1] ? value.split(separator)[1].length : 0;
     }
   }
 

--- a/src/__tests__/DateTimeField-test.js
+++ b/src/__tests__/DateTimeField-test.js
@@ -253,7 +253,31 @@ describe("DateTimeField", function () {
     });
   });
 
+  describe('yearDigits', () => {
+    let component;
 
+    describe('on date mode', () => {
+      it('returns the digits of the year', () => {
+        component = TestUtils.renderIntoDocument(<DateTimeField dateTime={happyDate.format("x")}
+                                                                inputFormat='DD/MM/YY' mode="date"/>);
+        expect(component.yearDigits('12/10/2016')).toEqual(4);
+        expect(component.yearDigits('12/10/20')).toEqual(2);
+        expect(component.yearDigits('12 10 ')).toEqual(0);
+        expect(component.yearDigits('12-10')).toEqual(0);
+      });
+    });
+
+    describe('on month mode', () => {
+      it('returns the digits of the year', () => {
+        component = TestUtils.renderIntoDocument(<DateTimeField dateTime={happyDate.format("x")}
+                                                                inputFormat='MM/YYYY' mode="month"/>);
+        expect(component.yearDigits('10/2016')).toEqual(4);
+        expect(component.yearDigits('10 20')).toEqual(2);
+        expect(component.yearDigits('10-')).toEqual(0);
+        expect(component.yearDigits('1')).toEqual(0);
+      });
+    });
+  });
 
   describe('onKeyDown', () => {
     let component, formatValueForEventMock;

--- a/src/__tests__/DateTimeField-test.js
+++ b/src/__tests__/DateTimeField-test.js
@@ -257,18 +257,18 @@ describe("DateTimeField", function () {
     let component;
 
     describe('on date mode', () => {
-      it('returns the digits of the year', () => {
+      it('returns the number of digits of the year', () => {
         component = TestUtils.renderIntoDocument(<DateTimeField dateTime={happyDate.format("x")}
                                                                 inputFormat='DD/MM/YY' mode="date"/>);
         expect(component.yearDigits('12/10/2016')).toEqual(4);
-        expect(component.yearDigits('12/10/20')).toEqual(2);
+        expect(component.yearDigits('12.10.20')).toEqual(2);
         expect(component.yearDigits('12 10 ')).toEqual(0);
         expect(component.yearDigits('12-10')).toEqual(0);
       });
     });
 
     describe('on month mode', () => {
-      it('returns the digits of the year', () => {
+      it('returns the number of digits of the year', () => {
         component = TestUtils.renderIntoDocument(<DateTimeField dateTime={happyDate.format("x")}
                                                                 inputFormat='MM/YYYY' mode="month"/>);
         expect(component.yearDigits('10/2016')).toEqual(4);


### PR DESCRIPTION
Initially, the datepicker is assumes that date values are separated by a '/' for 'date mode' and a space for 'month mode'. This change will remove that assumption and take the separator from the date value itself. This is done by looking for any non-alphanumeric character in the string and using that as the separator.