### PR TITLE
Update to React 16 compatibility to handle split of prop types library.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myob/react-bootstrap-datetimepicker",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "description": "A bootstrap datetime picker component for React.js",
   "homepage": "http://dev.quri.com/react-bootstrap-datetimepicker/",
   "repository": {
@@ -95,6 +95,7 @@
   "dependencies": {
     "babel-runtime": "^5.6.18",
     "classnames": "^2.2.1",
-    "moment": "^2.8.2"
+    "moment": "^2.8.2",
+    "prop-types": "^15.6.0"
   }
 }

--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from 'prop-types'
 import ReactDOM from "react-dom";
 import moment from "moment";
 import classnames from "classnames";

--- a/src/DateTimePicker.js
+++ b/src/DateTimePicker.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from 'prop-types'
 import classNames from "classnames";
 import DateTimePickerDate from "./DateTimePickerDate.js";
 import DateTimePickerTime from "./DateTimePickerTime.js";

--- a/src/DateTimePickerDate.js
+++ b/src/DateTimePickerDate.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from 'prop-types'
 import DateTimePickerDays from "./DateTimePickerDays";
 import DateTimePickerMonths from "./DateTimePickerMonths";
 import DateTimePickerYears from "./DateTimePickerYears";

--- a/src/DateTimePickerDays.js
+++ b/src/DateTimePickerDays.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from 'prop-types'
 import moment from "moment";
 import classnames from "classnames";
 
@@ -113,4 +114,3 @@ export default class DateTimePickerDays extends Component {
     );
   }
 }
-

--- a/src/DateTimePickerHours.js
+++ b/src/DateTimePickerHours.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from 'prop-types'
 import Constants from "./Constants.js";
 
 export default class DateTimePickerHours extends Component {
@@ -91,4 +92,3 @@ export default class DateTimePickerHours extends Component {
     );
   }
 }
-

--- a/src/DateTimePickerMinutes.js
+++ b/src/DateTimePickerMinutes.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from 'prop-types'
 import Constants from "./Constants.js";
 
 export default class DateTimePickerMinutes extends Component {
@@ -61,4 +62,3 @@ export default class DateTimePickerMinutes extends Component {
     );
   }
 }
-

--- a/src/DateTimePickerMonths.js
+++ b/src/DateTimePickerMonths.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from 'prop-types'
 import classnames from "classnames";
 import moment from "moment";
 import Constants from "./Constants.js";

--- a/src/DateTimePickerTime.js
+++ b/src/DateTimePickerTime.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from 'prop-types'
 import DateTimePickerMinutes from "./DateTimePickerMinutes";
 import DateTimePickerHours from "./DateTimePickerHours";
 import Constants from "./Constants.js";

--- a/src/DateTimePickerYears.js
+++ b/src/DateTimePickerYears.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from 'prop-types'
 import classnames from "classnames";
 
 export default class DateTimePickerYears extends Component {


### PR DESCRIPTION
Hi Guys,
 As mentioned in the starbird issues (https://github.com/MYOB-Technology/starbird-issues/issues/4) here is the PR to fix the date time component for V16 compatability.

Just on a side note, the root repository for this isn't being maintained which means MYOB will be the source maintainer. Given this I've also bumped the version to the next major in a move to Major.Med.Minor versioning.

Cheers,
Jason